### PR TITLE
docs: add Feature Branch Model workflow commands

### DIFF
--- a/.claude/commands/cleanup-feature.md
+++ b/.claude/commands/cleanup-feature.md
@@ -1,0 +1,54 @@
+---
+description: Clean up after PR merge - switch to main and delete feature branch
+---
+
+You are helping the user clean up after their Pull Request has been merged.
+
+Follow these steps:
+
+1. **Get current branch name:**
+   ```bash
+   git branch --show-current
+   ```
+
+2. **Confirm with the user:**
+   - Ask if their PR has been merged
+   - Show them which branch will be deleted
+   - Ask for confirmation to proceed
+
+3. **Switch to main and update:**
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+4. **Delete the feature branch:**
+   ```bash
+   git branch -d <feature-branch-name>
+   ```
+
+   If the branch wasn't merged and user confirms they want to delete anyway:
+   ```bash
+   git branch -D <feature-branch-name>
+   ```
+
+5. **Verify remote branch was deleted:**
+   ```bash
+   git fetch --prune
+   ```
+
+6. **Confirm to the user:**
+   ```
+   ✅ Cleaned up successfully!
+
+   Current branch: main
+   Deleted local branch: <feature-branch-name>
+
+   You're ready to start a new feature with /start-feature
+   ```
+
+**Important:**
+- Only delete branches after PR is merged
+- Use `-d` for safe delete (checks if merged)
+- Use `-D` only if user explicitly confirms force delete
+- Always fetch with --prune to clean up stale remote references

--- a/.claude/commands/finish-feature.md
+++ b/.claude/commands/finish-feature.md
@@ -1,0 +1,76 @@
+---
+description: Commit changes and create a Pull Request
+---
+
+You are helping the user finish their feature branch and create a Pull Request following the Feature Branch Model workflow.
+
+Follow these steps:
+
+1. **Check current status:**
+   ```bash
+   git status
+   ```
+
+2. **Show the user what files have changed** and ask for confirmation to proceed
+
+3. **Ask for commit details:**
+   - Commit type: feat, fix, docs, refactor, chore, test, perf
+   - Short description (1 line)
+   - Optional: Longer description
+   - Optional: Related issue number
+
+4. **Stage and commit changes:**
+   ```bash
+   git add .
+   git commit -m "$(cat <<'EOF'
+   <type>: <description>
+
+   <optional longer description>
+
+   <optional: Closes #123>
+   EOF
+   )"
+   ```
+
+5. **Push to remote:**
+   ```bash
+   git push -u origin <current-branch-name>
+   ```
+
+6. **Create Pull Request:**
+   ```bash
+   gh pr create --base main --head <current-branch-name> --title "<type>: <description>" --body "$(cat <<'EOF'
+   ## Summary
+   <bullet points summarizing changes>
+
+   ## Changes
+   <detailed list of changes>
+
+   ## Test plan
+   - [ ] Item 1
+   - [ ] Item 2
+
+   EOF
+   )"
+   ```
+
+7. **Display the PR URL** to the user
+
+8. **Remind the user of next steps:**
+   ```
+   ✅ Pull Request created!
+
+   Next steps:
+   - Review the PR at <URL>
+   - Wait for approval
+   - After merge, switch back to main:
+     git checkout main
+     git pull origin main
+     git branch -d <branch-name>
+   ```
+
+**Important:**
+- Use conventional commit format
+- Include the Claude Code footer in commits
+- Always create PRs against `main` branch
+- Provide clear, descriptive PR titles and descriptions

--- a/.claude/commands/start-feature.md
+++ b/.claude/commands/start-feature.md
@@ -1,0 +1,42 @@
+---
+description: Start working on a new feature branch
+---
+
+You are helping the user start working on a new feature following the Feature Branch Model workflow.
+
+Follow these steps:
+
+1. **Ask the user for the branch name** using the format: `feature/description`, `fix/description`, `docs/description`, `refactor/description`, or `chore/description`
+   - Example: "What would you like to name your branch? (e.g., feature/add-login, fix/auth-bug)"
+
+2. **Execute the workflow:**
+   ```bash
+   # Switch to main branch
+   git checkout main
+
+   # Pull latest changes from remote
+   git pull origin main
+
+   # Create and switch to new feature branch
+   git checkout -b <branch-name>
+   ```
+
+3. **Confirm to the user:**
+   - Current branch name
+   - That they're ready to start working
+   - Remind them to make commits as they work
+
+4. **Display next steps:**
+   ```
+   ✅ Ready to work on <branch-name>
+
+   Next steps:
+   - Make your changes
+   - Commit regularly: git commit -m "type: description"
+   - When done, use /finish-feature to create a PR
+   ```
+
+**Important:**
+- Always pull from `origin/main` first to get latest changes
+- Use conventional commit prefixes: feat, fix, docs, refactor, chore, test, perf
+- Branch names should be lowercase with hyphens


### PR DESCRIPTION
## Summary
- Added three slash commands to support the Feature Branch Model workflow
- Commands enable efficient feature branch creation, PR submission, and cleanup

## Changes
- Added `/start-feature` command to create and switch to new feature branches
- Added `/finish-feature` command to commit changes and create Pull Requests
- Added `/cleanup-feature` command to clean up merged feature branches
- All commands follow the Feature Branch Model as documented in git-workflow.md

## Test plan
- [x] Commands created with proper markdown formatting
- [x] Commands follow project conventions
- [ ] Test `/start-feature` to create a new branch
- [ ] Test `/finish-feature` to commit and create PR
- [ ] Test `/cleanup-feature` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)