### PR TITLE
fix: expose Logstash HTTP port 8080 for Python application logging

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -416,6 +416,7 @@ services:
       - logstash_data:/usr/share/logstash/data
     ports:
       - "127.0.0.1:5000:5000"  # TCP input for application logs (localhost only)
+      - "127.0.0.1:8080:8080"  # HTTP input for application logs (localhost only)
       - "127.0.0.1:9600:9600"  # Monitoring API (localhost only)
       - "127.0.0.1:12201:12201/udp"  # GELF UDP input for Docker containers (localhost only)
     networks:


### PR DESCRIPTION
## Summary
- Fixed Python backend logs not reaching ELK stack by exposing Logstash HTTP port 8080

## Problem
The Python backend uses `LogstashHandler` which sends logs via HTTP POST to Logstash port 8080. However, this port was not exposed to the host in `docker-compose.prod.yml`, causing all application logs to fail silently.

## Changes
### `docker-compose.prod.yml`
- Added port mapping `127.0.0.1:8080:8080` for Logstash HTTP input (line 419)
- Enables local Python app to send logs to Logstash HTTP endpoint

## Root Cause Analysis
1. **Port Mismatch**: Python app configured to use HTTP POST on port 8080
2. **Missing Exposure**: Port 8080 listening inside container but not exposed to host
3. **Silent Failure**: LogstashHandler fails gracefully without crashing the app

## Verification
✅ Logstash HTTP endpoint accessible at `localhost:8080`  
✅ Test logs successfully reaching Elasticsearch  
✅ Logs queryable in Kibana at http://localhost:5601  
✅ Python LogstashHandler integration tested and working

## Configuration Required
Users need to update their `.env` file:
```bash
LOGSTASH_PORT=8080
```

## Test Plan
- [x] Verify Logstash container starts with new port mapping
- [x] Test HTTP endpoint responds: `curl -X POST http://localhost:8080 -d '{"test":"log"}'`
- [x] Confirm logs appear in Elasticsearch indices
- [x] Test Python LogstashHandler sends logs successfully
- [x] Verify logs are searchable in Kibana UI

## Related Documentation
- `backend/utils/logstash_handler.py` - Python logging handler
- `backend/config.py:156-158` - Logstash configuration settings
- `logstash/pipeline/logstash.conf:3-8` - HTTP input configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)